### PR TITLE
Add option to remove animated sliding effect

### DIFF
--- a/js/adapt-contrib-blockslider.js
+++ b/js/adapt-contrib-blockslider.js
@@ -150,7 +150,11 @@ define([
 
       navigateToIndex: function(stage, movementSize) {
         if (stage < this.model.get('_blockCount') && stage >= 0) {
-          this.$('.blockslider').stop().animate({'margin-left': - (movementSize * stage)});
+        	if (this.model.get('_blockSlider')._noAnimate === true) {
+          	this.$('.blockslider').stop().css({'margin-left': - (movementSize * stage)});
+          } else {
+          	this.$('.blockslider').stop().animate({'margin-left': - (movementSize * stage)});
+          }
           this.setStage(stage);
         }
       },

--- a/properties.schema
+++ b/properties.schema
@@ -108,7 +108,16 @@
                   "inputType": "Text",
                   "validators": ["required"],
                   "help": "Fix the height of the blockslider to this value. For example, a value of 600 will set the blockslider to 600px high. Defaults to 'auto' if not specified."
-                }
+                },
+								"_noAnimate": {
+									"type": "boolean",
+									"required": false,
+									"default": false,
+									"title": "No animation",
+									"inputType": {"type": "Boolean", "options": [true, false]},
+									"validators": [],
+									"help": "Set to true to remove the animated sliding effect."
+								}
               }
             }
           }


### PR DESCRIPTION
Adds a _noAnimate property which if true removes the animation. Useful when using tabs, so that they behave like tabs.