### PR TITLE
Formatting only and version bump

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-blockslider",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "framework": "^2.0.0",
   "homepage": "https://github.com/LearningPool/adapt-contrib-blockslider",
   "issues": "https://github.com/LearningPool/adapt-contrib-blockslider/issues",

--- a/js/adapt-contrib-blockslider.js
+++ b/js/adapt-contrib-blockslider.js
@@ -7,7 +7,7 @@ define([
   'coreJS/adapt'
 ], function(Adapt) {
 
-  function setupBlockSliderView (blockSliderArticle) {
+  function setupBlockSliderView(blockSliderArticle) {
 
     var BlockSliderView = Backbone.View.extend({
 
@@ -16,8 +16,8 @@ define([
       el: '.' + blockSliderArticle.get('_id'),
 
       events: {
-        'click .blockslider-controls' : 'navigateClick',
-        'click .blockslider-tab' : 'navigateTab'
+        'click .blockslider-controls': 'navigateClick',
+        'click .blockslider-tab': 'navigateTab'
       },
 
       initialize: function() {
@@ -45,13 +45,13 @@ define([
       },
 
       setInitialSlide: function() {
-        var initialSlide = this.model.get('_blockSlider')._initial ? this.model.get('_blockSlider')._initial-1 : 0;
+        var initialSlide = this.model.get('_blockSlider')._initial ? this.model.get('_blockSlider')._initial - 1 : 0;
         var movementSize = this.$('.blockslider-container').width();
-        this.$('.blockslider').css({'margin-left': - (movementSize * initialSlide)});
+        this.$('.blockslider').css({ 'margin-left': - (movementSize * initialSlide) });
         this.setStage(initialSlide);
       },
 
-      render: function () {
+      render: function() {
         // Add controls to the article
         var data = this.model.toJSON();
         var template = Handlebars.templates["blockslider"];
@@ -70,13 +70,13 @@ define([
       },
 
       wrapBlocks: function() {
-        this.$(".block").wrapAll( "<div class='blockslider' />");
+        this.$(".block").wrapAll("<div class='blockslider' />");
         this.$(".blockslider").wrapAll("<div class='blockslider-container' />");
         this.$('.blockslider-controls-container').removeClass('blockslider-hidden');
         this.model.set('_active', true);
       },
 
-      getAvailableBlocks: function () {
+      getAvailableBlocks: function() {
         return _.filter(this.model.getChildren().models, function(block) {
           return block.get('_isAvailable');
         });
@@ -125,7 +125,7 @@ define([
         this.$('.blockslider').css('margin-left', margin);
       },
 
-      navigateClick: function (event) {
+      navigateClick: function(event) {
         event.preventDefault();
 
         var stage = this.model.get('_stage');
@@ -139,7 +139,7 @@ define([
         }
       },
 
-      navigateTab: function (event) {
+      navigateTab: function(event) {
         event.preventDefault();
         this.$('.blockslider-tab').removeClass('active');
         this.$(event.currentTarget).addClass('active');
@@ -150,7 +150,7 @@ define([
 
       navigateToIndex: function(stage, movementSize) {
         if (stage < this.model.get('_blockCount') && stage >= 0) {
-          this.$('.blockslider').stop().animate({'margin-left': - (movementSize * stage)});
+          this.$('.blockslider').stop().animate({ 'margin-left': - (movementSize * stage) });
           this.setStage(stage);
         }
       },
@@ -196,7 +196,7 @@ define([
 
     });
 
-    new BlockSliderView({model: blockSliderArticle});
+    new BlockSliderView({ model: blockSliderArticle });
   }
 
   function onArticleViewPreRender(article) {

--- a/less/blockslider.less
+++ b/less/blockslider.less
@@ -1,38 +1,40 @@
 .blockslider-article {
-
   .blockslider-container {
     margin: 0 auto;
     overflow: hidden;
 
     .blockslider {
       height: auto;
+
       .block {
+        float: left;
         height: auto;
-        float:left;
       }
     }
   }
 
   .blockslider-controls-container {
     height: auto;
-    text-align: center;
+    margin-top: 5px;
     position: relative;
-    margin-top:5px;
+    text-align: center;
   }
 
   .blockslider-text-tab {
-    padding: @item-padding;
-    color: @item-text-color;
     background-color: @item-color;
-    margin-top:8px;
-    margin-right:5px;
+    color: @item-text-color;
+    margin-right: 5px;
+    margin-top: 8px;
+    padding: @item-padding;
+
     .no-touch &:hover {
-      text-color: @item-text-color-hover;
       background-color: @item-color-hover;
+      color: @item-text-color-hover;
     }
     &.active {
       background-color: @item-selected-color;
       color: @item-text-selected-color;
+
       .no-touch &:hover {
         background-color: @item-selected-color;
         color: @item-text-selected-color;
@@ -41,43 +43,49 @@
   }
 
   .blockslider-progress {
-    display: inline-block;
-    padding: @item-padding/2;
     background-color: @background-color;
     border: @item-border;
     border-radius: 50%;
+    display: inline-block;
     margin: 1px;
+    padding: @item-padding / 2;
+
     .no-touch &:hover {
       border-color: @item-border-color-hover;
     }
+
     &.active {
       background-color: @primary-color;
+
       .no-touch &:hover {
-        border-color: @item-border-color;
         background-color: @primary-color;
+        border-color: @item-border-color;
       }
     }
   }
 
   .blockslider-controls {
-    display: block;
-    width: (@icon-size*2);
-    height: (@icon-size*2);
-    position: absolute;
-    top: 50%;
-    margin-top: -(@icon-size);
-    z-index: 10;
-    text-decoration: none;
     background-color: @item-color;
+    display: block;
+    height: (@icon-size*2);
+    margin-top: -(@icon-size);
+    position: absolute;
+    text-decoration: none;
+    top: 50%;
+    width: (@icon-size*2);
+    z-index: 10;
+
     .no-touch &:hover {
       background-color: @item-color-hover;
+
       .icon {
         color: @item-text-color-hover;
       }
     }
+
     .icon {
-      margin: (@icon-size/2);
       color: @item-text-color;
+      margin: (@icon-size / 2);
     }
   }
 
@@ -93,5 +101,4 @@
     display: none;
     visibility: hidden;
   }
-
 }


### PR DESCRIPTION
This is to bump the version beyond what exists on live (somehow it is v2.0.1 but that tag does not exist)

This will prevent the image update emails without worrying about losing any history of having the plugin and maintaining historical courses